### PR TITLE
Fixed bug where backup routine did not close file handle after finsihed

### DIFF
--- a/agent/workers/backup.go
+++ b/agent/workers/backup.go
@@ -1,7 +1,6 @@
 package workers
 
 import (
-	"bufio"
 	"encoding/hex"
 	"io"
 	"os"
@@ -90,6 +89,7 @@ func (b *Backup) Do(file string) *spec.JobFile {
 		jf.State = spec.Errors
 		return jf
 	}
+	defer fileHandle.Close()
 
 	errc := make(chan error)
 	done := make(chan bool)
@@ -106,7 +106,7 @@ func (b *Backup) Do(file string) *spec.JobFile {
 	}
 
 	//setup the pipeline
-	pipe := modifications.NewPipeline(bufio.NewReader(fileHandle), errc, true, b.Modifications...)
+	pipe := modifications.NewPipeline(fileHandle, errc, true, b.Modifications...)
 
 	//copy the data
 	go func() {

--- a/agent/workers/restore.go
+++ b/agent/workers/restore.go
@@ -1,7 +1,6 @@
 package workers
 
 import (
-	"bufio"
 	"io"
 
 	"github.com/sethjback/gobl/engines"
@@ -51,7 +50,7 @@ func (r *Restore) Do(fileSig *files.Signature) *spec.JobFile {
 	go r.To.Restore(pipeR, *fileSig, errc)
 
 	//setup the decode pipeline
-	pipe := modifications.NewPipeline(bufio.NewReader(reader), errc, false, r.Modifications...)
+	pipe := modifications.NewPipeline(reader, errc, false, r.Modifications...)
 
 	//copy the data
 	go func() {

--- a/engines/localfile.go
+++ b/engines/localfile.go
@@ -221,8 +221,8 @@ func (e *LocalFile) Restore(reader io.Reader, fileSig files.Signature, errc chan
 		errc <- err
 		return
 	}
-
 	defer rFile.Close()
+
 	if _, err := io.Copy(rFile, reader); err != nil {
 		errc <- err
 		return


### PR DESCRIPTION
Removed buffers for file reads to get rid of double buffereing (io.copy uses its own buffer)
